### PR TITLE
Prime numbers ex

### DIFF
--- a/week5_exercises/prime_numbers.py
+++ b/week5_exercises/prime_numbers.py
@@ -1,0 +1,26 @@
+
+def genPrimes():
+      x = 1
+      total_factors = []
+      prime_numbers = []
+
+      while True :
+            for number in range(1, x + 1):
+                  if x % number == 0:
+                        total_factors.append(number) 
+
+            if len(total_factors) == 2:
+                  prime_numbers.append(x)
+            
+            yield prime_numbers 
+            total_factors = []
+            x += 1
+
+primes = genPrimes()
+
+print(next(primes))
+print(next(primes))
+print(next(primes))
+print(next(primes))
+print(next(primes))
+print(next(primes))


### PR DESCRIPTION
@paulghaddad Question: I have to call "next" twice in order to get the function to add the next prime number to the list.  

Example output based on "next" calls:
[2]
[2, 3]
[2, 3]
[2, 3, 5]
[2, 3, 5]
--->Notice that I have to return "next" twice before the next prime number is returned. Why is this?